### PR TITLE
wire central security-pipelines

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,6 +10,7 @@ on:
       - "**/*.scss"
       - "Gemfile"
       - "Gemfile.lock"
+      - ".github/workflows/security.yml"
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,40 @@
+name: security
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.rb"
+      - "**/*.html"
+      - "**/*.md"
+      - "**/*.scss"
+      - "Gemfile"
+      - "Gemfile.lock"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  sast:
+    if: github.event_name == 'pull_request'
+    uses: binbashburns/security-pipelines/.github/workflows/sast.yml@main
+    with:
+      language: ruby
+
+  sbom:
+    uses: binbashburns/security-pipelines/.github/workflows/sbom-vuln.yml@main
+
+  secrets:
+    uses: binbashburns/security-pipelines/.github/workflows/secrets.yml@main
+
+  link-check:
+    uses: binbashburns/security-pipelines/.github/workflows/link-check.yml@main
+    with:
+      paths: "**/*.html **/*.md"
+      create-issue: true


### PR DESCRIPTION
Wire this repo to the central reusable workflows in [binbashburns/security-pipelines](https://github.com/binbashburns/security-pipelines). Reference: [devsecops.binbashburns.com](https://devsecops.binbashburns.com).

`paths:` filter scopes runs to file types that matter for this stack. Existing CI is untouched.